### PR TITLE
Make use of tokens for REST2 authentication

### DIFF
--- a/5.0/apache.rt.conf
+++ b/5.0/apache.rt.conf
@@ -4,6 +4,7 @@ FcgidMaxRequestLen 1073741824
     AddDefaultCharset UTF-8
     DocumentRoot /opt/rt5/share/html
     ScriptAlias / /opt/rt5/sbin/rt-server.fcgi/
+    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
     <Location />
         require all granted
     </Location>


### PR DESCRIPTION
RT 5.0 has integrated v2 of the REST API and the Token authentication
module into core.

Tokens are used specifically for accessing the API.

Without this directive, the tokens are not permitting access to the API.

ps. I've left out the apache.rt.conf file in RT 4.x and the template
since I don't believe the Token authentication plugin is installed in
the 4.x images.